### PR TITLE
Hold the full path of initial file during copy

### DIFF
--- a/fixpatches/src/commonMain/kotlin/com/saveourtool/sarifutils/adapter/SarifFixAdapter.kt
+++ b/fixpatches/src/commonMain/kotlin/com/saveourtool/sarifutils/adapter/SarifFixAdapter.kt
@@ -229,7 +229,11 @@ class SarifFixAdapter(
      */
     @Suppress("TOO_LONG_FUNCTION")
     private fun applyReplacementsToSingleFile(targetFile: Path, replacements: List<Replacement>): Path {
-        val targetFileCopy = tmpDir.resolve(targetFile.name)
+        val targetFileCopy = tmpDir.resolve(targetFile)
+        // additionally create parent directories, before copy of content
+        targetFileCopy.parent?.let {
+            fs.createDirectories(it)
+        }
         fs.copy(targetFile, targetFileCopy)
 
         val fileContent = readLines(targetFileCopy).toMutableList()

--- a/fixpatches/src/commonMain/kotlin/com/saveourtool/sarifutils/adapter/SarifFixAdapter.kt
+++ b/fixpatches/src/commonMain/kotlin/com/saveourtool/sarifutils/adapter/SarifFixAdapter.kt
@@ -232,7 +232,9 @@ class SarifFixAdapter(
         val targetFileCopy = tmpDir.resolve(targetFile)
         // additionally create parent directories, before copy of content
         targetFileCopy.parent?.let {
-            fs.createDirectories(it)
+            if (!fs.exists(it)) {
+                fs.createDirectories(it)
+            }
         }
         fs.copy(targetFile, targetFileCopy)
 


### PR DESCRIPTION
### What's done:
* Hold the full path of initial file during copy