### PR TITLE
Use log4j-slf4j2-impl only in tests

### DIFF
--- a/fixpatches/build.gradle.kts
+++ b/fixpatches/build.gradle.kts
@@ -16,11 +16,11 @@ kotlin {
                 implementation(libs.sarif4k)
                 implementation(libs.multiplatform.diff)
                 implementation(libs.kotlin.logging)
-                implementation(libs.log4j.core)
             }
         }
         val commonTest by getting {
             dependencies {
+                implementation(libs.log4j.core)
                 implementation(libs.log4j.slf4j2.impl)
             }
         }

--- a/fixpatches/build.gradle.kts
+++ b/fixpatches/build.gradle.kts
@@ -16,8 +16,12 @@ kotlin {
                 implementation(libs.sarif4k)
                 implementation(libs.multiplatform.diff)
                 implementation(libs.kotlin.logging)
-                implementation(libs.log4j.slf4j2.impl)
                 implementation(libs.log4j.core)
+            }
+        }
+        val commonTest by getting {
+            dependencies {
+                implementation(libs.log4j.slf4j2.impl)
             }
         }
     }


### PR DESCRIPTION
### What's done:
* Use log4j-slf4j2-impl only in tests