### PR TITLE
Correct path manipulation on Windows and UNIX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ target
 .gradle
 build
 /.idea
+/.run/
 *.iml
 out
 .DS_Store

--- a/fixpatches/build.gradle.kts
+++ b/fixpatches/build.gradle.kts
@@ -5,6 +5,18 @@ plugins {
     `maven-publish`
 }
 
+repositories {
+    mavenCentral()
+    maven {
+        name = "saveourtool/okio-extras"
+        url = uri("https://maven.pkg.github.com/saveourtool/okio-extras")
+        credentials {
+            username = project.findProperty("gprUser") as String? ?: System.getenv("GITHUB_ACTOR")
+            password = project.findProperty("gprKey") as String? ?: System.getenv("GITHUB_TOKEN")
+        }
+    }
+}
+
 kotlin {
     jvm()
 
@@ -12,6 +24,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 api(libs.okio)
+                implementation(libs.okio.extras)
                 implementation(libs.kotlinx.serialization.json)
                 implementation(libs.sarif4k)
                 implementation(libs.multiplatform.diff)

--- a/fixpatches/src/commonMain/kotlin/com/saveourtool/sarifutils/adapter/SarifFixAdapter.kt
+++ b/fixpatches/src/commonMain/kotlin/com/saveourtool/sarifutils/adapter/SarifFixAdapter.kt
@@ -244,7 +244,7 @@ class SarifFixAdapter(
             log.warn { "The list of replacements is empty." }
         }
         if (targetFiles.isEmpty()) {
-            log.warn { "The list of replacements is empty." }
+            log.warn { "The list of target files is empty." }
         }
 
         return fileReplacementsList.mapNotNull { fileReplacements ->

--- a/fixpatches/src/commonMain/kotlin/com/saveourtool/sarifutils/adapter/SarifFixAdapter.kt
+++ b/fixpatches/src/commonMain/kotlin/com/saveourtool/sarifutils/adapter/SarifFixAdapter.kt
@@ -1,3 +1,8 @@
+@file:Suppress(
+    "FILE_IS_TOO_LONG",
+    "FILE_UNORDERED_IMPORTS",  // false positive
+)
+
 package com.saveourtool.sarifutils.adapter
 
 import com.saveourtool.okio.Uri
@@ -227,7 +232,10 @@ class SarifFixAdapter(
      * @param fileReplacementsList list of replacements from all rules
      * @param targetFiles list of target files
      */
-    @Suppress("MaxLineLength")
+    @Suppress(
+        "MaxLineLength",
+        "TOO_LONG_FUNCTION",
+    )
     private fun applyReplacementsToFiles(
         fileReplacementsList: List<FileReplacements>,
         targetFiles: List<Path>,

--- a/fixpatches/src/commonMain/kotlin/com/saveourtool/sarifutils/files/FileUtils.kt
+++ b/fixpatches/src/commonMain/kotlin/com/saveourtool/sarifutils/files/FileUtils.kt
@@ -13,51 +13,6 @@ import kotlin.random.Random
 expect val fs: FileSystem
 
 /**
- * @param path a path to a file
- * @return list of strings from the file
- */
-internal fun readLines(path: Path): List<String> = fs.read(path) {
-    generateSequence { readUtf8Line() }.toList()
-}
-
-/**
- * @param path a path to a file
- * @return string from the file
- */
-internal fun readFile(path: Path): String = fs.read(path) {
-    this.readUtf8()
-}
-
-/**
- * Write [content] to the [targetFile], some of the elements in [content] could represent the multiline strings,
- * which already contain all necessary escape characters, in this case, write them as-is, otherwise add newline at the end
- *
- * @param targetFile file whether to write [content]
- * @param content data to be written
- * @return [Unit]
- */
-internal fun writeContentWithNewLinesToFile(targetFile: Path, content: List<String>) = fs.write(targetFile) {
-    content.forEach { line ->
-        if (!line.contains('\n')) {
-            writeUtf8(line + '\n')
-        } else {
-            writeUtf8(line)
-        }
-    }
-}
-
-/**
- * Create a temporary directory
- *
- * @param prefix will be prepended to directory name
- * @return a [Path] representing the created directory
- */
-internal fun createTempDir(prefix: String = "sarifutils-tmp"): Path {
-    val dirName = "$prefix-${Random.nextInt()}"
-    return (FileSystem.SYSTEM_TEMPORARY_DIRECTORY / dirName).createDirectories()
-}
-
-/**
  * Returns the _real_ path of an existing file.
  *
  * If this path is relative then its absolute path is first obtained, as if by
@@ -140,10 +95,54 @@ internal fun Path.createDirectories(): Path {
  * @return this path relativized against [other],
  *   or `this` if this and other have different file system roots.
  */
-internal fun Path.relativeToSafe(other: Path): Path {
-    return try {
-        relativeTo(other)
-    } catch (_: IllegalArgumentException) {
-        this
+internal fun Path.relativeToSafe(other: Path): Path =
+        try {
+            relativeTo(other)
+        } catch (_: IllegalArgumentException) {
+            this
+        }
+
+/**
+ * @param path a path to a file
+ * @return list of strings from the file
+ */
+internal fun readLines(path: Path): List<String> = fs.read(path) {
+    generateSequence { readUtf8Line() }.toList()
+}
+
+/**
+ * @param path a path to a file
+ * @return string from the file
+ */
+internal fun readFile(path: Path): String = fs.read(path) {
+    this.readUtf8()
+}
+
+/**
+ * Write [content] to the [targetFile], some of the elements in [content] could represent the multiline strings,
+ * which already contain all necessary escape characters, in this case, write them as-is, otherwise add newline at the end
+ *
+ * @param targetFile file whether to write [content]
+ * @param content data to be written
+ * @return [Unit]
+ */
+internal fun writeContentWithNewLinesToFile(targetFile: Path, content: List<String>) = fs.write(targetFile) {
+    content.forEach { line ->
+        if (!line.contains('\n')) {
+            writeUtf8(line + '\n')
+        } else {
+            writeUtf8(line)
+        }
     }
+}
+
+/**
+ * Create a temporary directory
+ *
+ * @param prefix will be prepended to directory name
+ * @return a [Path] representing the created directory
+ */
+internal fun createTempDir(prefix: String = "sarifutils-tmp"): Path {
+    val dirName = "$prefix-${Random.nextInt()}"
+    return (FileSystem.SYSTEM_TEMPORARY_DIRECTORY / dirName).createDirectories()
 }

--- a/fixpatches/src/commonMain/kotlin/com/saveourtool/sarifutils/files/FileUtils.kt
+++ b/fixpatches/src/commonMain/kotlin/com/saveourtool/sarifutils/files/FileUtils.kt
@@ -54,9 +54,7 @@ internal fun writeContentWithNewLinesToFile(targetFile: Path, content: List<Stri
  */
 internal fun createTempDir(prefix: String = "sarifutils-tmp"): Path {
     val dirName = "$prefix-${Random.nextInt()}"
-    return (FileSystem.SYSTEM_TEMPORARY_DIRECTORY / dirName).also {
-        fs.createDirectories(it)
-    }
+    return (FileSystem.SYSTEM_TEMPORARY_DIRECTORY / dirName).createDirectories()
 }
 
 /**
@@ -117,3 +115,35 @@ internal fun Path.isSameFileAsSafe(other: Path): Boolean =
         } catch (_: IOException) {
             this.toRealPathSafe() == other.toRealPathSafe()
         }
+
+/**
+ * Creates a directory, ensuring that all nonexistent parent directories exist
+ * by creating them first.
+ *
+ * If the directory already exists, this function does not throw an exception.
+ *
+ * @return this path.
+ * @throws IOException if an I/O error occurs.
+ */
+@Throws(IOException::class)
+internal fun Path.createDirectories(): Path {
+    fs.createDirectories(this)
+    return this
+}
+
+/**
+ * Same as [Path.relativeTo], but doesn't throw an [IllegalArgumentException] if
+ * `this` and [other] are both absolute paths, but have different file system
+ * roots.
+ *
+ * @param other the other path.
+ * @return this path relativized against [other],
+ *   or `this` if this and other have different file system roots.
+ */
+internal fun Path.relativeToSafe(other: Path): Path {
+    return try {
+        relativeTo(other)
+    } catch (_: IllegalArgumentException) {
+        this
+    }
+}

--- a/fixpatches/src/commonMain/kotlin/com/saveourtool/sarifutils/net/UrilUtils.kt
+++ b/fixpatches/src/commonMain/kotlin/com/saveourtool/sarifutils/net/UrilUtils.kt
@@ -1,0 +1,176 @@
+@file:JvmName("UriUtils")
+@file:Suppress("HEADER_MISSING_IN_NON_SINGLE_CLASS_FILE")
+
+package com.saveourtool.sarifutils.net
+
+import com.saveourtool.okio.BACKSLASH
+import com.saveourtool.okio.SLASH
+import com.saveourtool.okio.URI_UNC_PATH_PREFIX
+import com.saveourtool.okio.Uri
+import com.saveourtool.okio.backslashify
+import com.saveourtool.okio.slashify
+import com.saveourtool.okio.toLocalPath
+import com.saveourtool.system.OsFamily
+import okio.Path
+import okio.Path.Companion.toPath
+import kotlin.jvm.JvmName
+
+private typealias UriPath = CharSequence
+
+/**
+ * Converts this URI to a local path.
+ *
+ * Puts more effort into the conversion than [Uri.toLocalPath],
+ * covering some extra corner cases.
+ *
+ * @return the local path created from this `file://` or UNC URI.
+ * @throws IllegalArgumentException if the URI contains an absolute path from
+ *   the different platform (e.g.: a Windows path while the current OS is UNIX).
+ * @see Uri.toLocalPath
+ */
+@Suppress(
+    "CyclomaticComplexMethod",
+    "NestedBlockDepth",
+    "TOO_LONG_FUNCTION",
+)
+internal fun Uri.toLocalPathExt(): Path =
+        when {
+            isAbsoluteWindowsPath() -> {
+                val localPath = "$scheme:${path ?: schemeSpecificPart}"
+
+                localPath.requireOsIsWindows()
+
+                localPath.backslashify().toPath()
+            }
+
+            isAbsolute -> when (val path = path) {
+                /*
+                 * When a URI is opaque, its path is `null`.
+                 */
+                null -> schemeSpecificPart.toPath()
+
+                else -> {
+                    @Suppress("WHEN_WITHOUT_ELSE")
+                    when {
+                        /*
+                         * This is not 100% correct, as a
+                         * normalized UNC URI is indistinguishable
+                         * from a URI that holds an absolute
+                         * UNIX path, e.g.:
+                         * `file:/WSL$/Debian/etc/passwd`.
+                         */
+                        path.isAbsoluteUnixPath() && authority == null -> path.requireOsIsUnix()
+                        path.isAbsoluteWindowsPath() -> path.requireOsIsWindows()
+                        path.isUncPath() -> path.requireOsIsWindows()
+                    }
+
+                    toLocalPath()
+                }
+            }
+
+            else -> {
+                val path = path
+
+                check(path != null) {
+                    "The `path` part of the URI is null: $this"
+                }
+
+                path.run {
+                    when {
+                        OsFamily.isWindows() -> {
+                            if (isAbsoluteUnixPath()) {
+                                requireOsIsUnix()
+                            }
+
+                            backslashify()
+                        }
+
+                        else -> {
+                            if (isAbsoluteWindowsPath()) {
+                                requireOsIsWindows()
+                            }
+
+                            slashify()
+                        }
+                    }.toPath()
+                }
+            }
+        }
+
+/**
+ * Despite this is a misuse of the URI, it may well contain an absolute
+ * _Windows_ path in the form of `C:/path/to/file.ext`.
+ *
+ * @return `true` if this URI holds an absolute _Windows_ path, false otherwise.
+ */
+private fun Uri.isAbsoluteWindowsPath(): Boolean {
+    val scheme = scheme
+    val uriPath = path
+
+    return scheme != null &&
+            scheme.length == 1 &&
+            scheme[0].isWindowsDriveLetter() &&
+            when (uriPath) {
+                null -> schemeSpecificPart.startsWith(BACKSLASH)
+                else -> uriPath.startsWith(SLASH)
+            }
+}
+
+/**
+ * Applied to the [path][Uri.path] fragment of a URI. Returns `true` if the
+ * _path_ is an absolute Windows path (e.g.: `C:/autoexec.bat` or
+ * `/C:/autoexec.bat`).
+ *
+ * @return `true` if this is an absolute Windows path, `false` otherwise.
+ */
+@Suppress(
+    "MagicNumber",
+    "MAGIC_NUMBER",
+    "WRONG_NEWLINES",
+)
+private fun UriPath.isAbsoluteWindowsPath(): Boolean {
+    return when {
+        startsWith(SLASH) && length >= 4 -> subSequence(1..3)
+        length >= 3 -> subSequence(0..2)
+        else -> return false
+    }.let { prefix ->
+        prefix[0].isWindowsDriveLetter() &&
+                prefix[1] == ':' &&
+                prefix[2] in sequenceOf(SLASH, BACKSLASH)
+    }
+}
+
+/**
+ * Applied to the [path][Uri.path] fragment of a URI. Returns `true` if the
+ * _path_ is a UNC path (e.g.: `//host/share`).
+ *
+ * @return `true` if this is a UNC path, `false` otherwise.
+ */
+private fun UriPath.isUncPath(): Boolean =
+        startsWith(URI_UNC_PATH_PREFIX)
+
+/**
+ * Applied to the [path][Uri.path] fragment of a URI. Returns `true` if the
+ * _path_ is an absolute UNIX path (e.g.: `/etc/passwd`) and, at the same time,
+ * is not a slash followed by an absolute Windows path (e.g.: `/C:/autoexec.bat`).
+ *
+ * @return `true` if this is an absolute UNIX path, `false` otherwise.
+ */
+private fun UriPath.isAbsoluteUnixPath(): Boolean =
+        startsWith(SLASH) &&
+                !isUncPath() &&
+                !isAbsoluteWindowsPath()
+
+private fun UriPath.requireOsIsWindows() =
+        require(OsFamily.isWindows()) {
+            "Current OS is not a Windows; unable to construct an absolute Windows path from \"$this\""
+        }
+
+private fun UriPath.requireOsIsUnix() =
+        require(OsFamily.isUnix()) {
+            "Current OS is not a UNIX; unable to construct an absolute UNIX path from \"$this\""
+        }
+
+private fun Char.isWindowsDriveLetter(): Boolean =
+        this in 'A'..'Z' ||
+                this in 'a'..'z'

--- a/fixpatches/src/commonMain/kotlin/com/saveourtool/sarifutils/utils/SarifUtils.kt
+++ b/fixpatches/src/commonMain/kotlin/com/saveourtool/sarifutils/utils/SarifUtils.kt
@@ -4,6 +4,7 @@
 
 package com.saveourtool.sarifutils.utils
 
+import com.saveourtool.okio.backslashify
 import io.github.detekt.sarif4k.ArtifactLocation
 import io.github.detekt.sarif4k.Result
 import io.github.detekt.sarif4k.Run
@@ -32,7 +33,7 @@ internal fun Path.adaptedIsAbsolute(): Boolean {
             (stringRepresentation.first() in 'a'..'z' || stringRepresentation.first() in 'A'..'Z') &&
             (stringRepresentation[1] == ':')
     ) {
-        return stringRepresentation.replace('/', '\\').toPath().isAbsolute
+        return stringRepresentation.backslashify().toPath().isAbsolute
     }
     return this.isAbsolute
 }

--- a/fixpatches/src/commonTest/kotlin/com/saveourtool/sarifutils/net/UriUtilsTest.kt
+++ b/fixpatches/src/commonTest/kotlin/com/saveourtool/sarifutils/net/UriUtilsTest.kt
@@ -1,0 +1,287 @@
+package com.saveourtool.sarifutils.net
+
+import com.saveourtool.okio.BACKSLASH
+import com.saveourtool.okio.SLASH
+import com.saveourtool.okio.Uri
+import com.saveourtool.okio.absolute
+import com.saveourtool.okio.pathString
+import com.saveourtool.okio.toFileUri
+import com.saveourtool.system.OsFamily
+import okio.Path
+import okio.Path.Companion.toPath
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class UriUtilsTest {
+    @BeforeTest
+    fun before() {
+        assertFalse(OsFamily.isUnknown(), OsFamily.osName())
+    }
+
+    @Test
+    fun `absolute URIs from absolute paths - platform-independent`() {
+        sequenceOf(
+            "path/to/file.ext",
+            "./path/to/file.ext",
+        )
+            .map { it.toPath() }
+            .map(Path::toFileUri)
+            .flatMap { uri ->
+                sequenceOf(
+                    uri,
+                    uri.normalize(),
+                )
+            }
+            .distinctBy(Uri::toString)
+            .map(Uri::toLocalPathExt)
+            .map(Path::normalized)
+            .forEach { path ->
+                assertEquals(
+                    expected = "".toPath().absolute() / "path" / "to" / "file.ext",
+                    actual = path.normalized(),
+                )
+            }
+    }
+
+    @Test
+    fun `absolute URIs from relative paths`() {
+        sequenceOf(
+            "file:file.ext",
+            "file:./file.ext",
+            "file:./path/to/../../file.ext",
+        )
+            .map { Uri(it) }
+            .forEach { uri ->
+                assertTrue(uri.isAbsolute)
+                assertTrue(uri.isOpaque)
+                assertEquals(expected = "file", actual = uri.scheme)
+                assertEquals(
+                    expected = "file.ext".toPath(),
+                    actual = uri.toLocalPathExt().normalized()
+                )
+            }
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `absolute URIs from absolute Windows paths`() {
+        sequenceOf(
+            "file:///C:/autoexec.bat",
+            "file:/C:/autoexec.bat",
+        )
+            .map { Uri(it) }
+            .forEach { uri ->
+                assertTrue(uri.isAbsolute)
+                assertFalse(uri.isOpaque)
+                assertEquals(expected = "file", actual = uri.scheme)
+
+                when {
+                    OsFamily.isWindows() -> assertEquals(expected = "C:\\autoexec.bat".toPath(), actual = uri.toLocalPathExt().normalized())
+
+                    else -> assertEquals(
+                        expected = "Current OS is not a Windows; unable to construct an absolute Windows path from \"/C:/autoexec.bat\"",
+                        actual = assertFailsWith<IllegalArgumentException> {
+                            uri.toLocalPathExt()
+                        }.message,
+                    )
+                }
+            }
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `absolute URIs from absolute UNIX paths`() {
+        sequenceOf(
+            "file:///etc/passwd",
+            "file:/etc/passwd",
+        )
+            .map { Uri(it) }
+            .forEach { uri ->
+                assertTrue(uri.isAbsolute)
+                assertFalse(uri.isOpaque)
+                assertEquals(expected = "file", actual = uri.scheme)
+
+                when {
+                    OsFamily.isUnix() -> assertEquals(
+                        expected = "/etc/passwd".toPath(),
+                        actual = uri.toLocalPathExt().normalized()
+                    )
+
+                    else -> assertEquals(
+                        expected = "Current OS is not a UNIX; unable to construct an absolute UNIX path from \"/etc/passwd\"",
+                        actual = assertFailsWith<IllegalArgumentException> {
+                            uri.toLocalPathExt()
+                        }.message,
+                    )
+                }
+            }
+    }
+
+    @Test
+    fun `relative URIs from relative paths`() {
+        sequenceOf(
+            "file.ext",
+            "./file.ext",
+            "./path/to/../../file.ext",
+        )
+            .map { Uri(it) }
+            .forEach { uri ->
+                assertFalse(uri.isAbsolute)
+                assertFalse(uri.isOpaque)
+                assertNull(uri.scheme)
+                assertEquals(
+                    expected = "file.ext".toPath(),
+                    actual = uri.toLocalPathExt().normalized()
+                )
+            }
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `relative URIs from absolute Windows paths`() {
+        @Suppress("COMMENT_WHITE_SPACE")
+        sequenceOf(
+            "C:/autoexec.bat",      // forward slash
+            "C:%5Cautoexec.bat",    // backslash
+            "C%3A%2Fautoexec.bat",  // forward slash
+            "C%3A%5Cautoexec.bat",  // backslash
+        )
+            .map { Uri(it) }
+            .forEach { uri ->
+                when {
+                    OsFamily.isWindows() -> assertEquals(expected = "C:\\autoexec.bat".toPath(), actual = uri.toLocalPathExt().normalized())
+
+                    else -> assertEquals(
+                        expected = "Current OS is not a Windows; unable to construct an absolute Windows path from \"C:\\autoexec.bat\"",
+                        actual = assertFailsWith<IllegalArgumentException> {
+                            uri.toLocalPathExt()
+                        }.message?.replace(SLASH, BACKSLASH),
+                    )
+                }
+            }
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `relative URIs from absolute UNIX paths`() {
+        sequenceOf(
+            "/etc/passwd",
+            "%2Fetc%2Fpasswd",
+        )
+            .map { Uri(it) }
+            .forEach { uri ->
+                when {
+                    OsFamily.isUnix() -> assertEquals(
+                        expected = "/etc/passwd".toPath(),
+                        actual = uri.toLocalPathExt().normalized()
+                    )
+
+                    else -> assertEquals(
+                        expected = "Current OS is not a UNIX; unable to construct an absolute UNIX path from \"/etc/passwd\"",
+                        actual = assertFailsWith<IllegalArgumentException> {
+                            uri.toLocalPathExt()
+                        }.message,
+                    )
+                }
+            }
+    }
+
+    @Test
+    fun `paths with spaces`() {
+        sequenceOf(
+            "file:Program%20Files",
+            "file:./Program%20Files",
+            "Program%20Files",
+            "./Program%20Files",
+        )
+            .map { Uri(it) }
+            .forEach { uri ->
+                assertEquals(
+                    expected = "Program Files".toPath(),
+                    actual = uri.toLocalPathExt().normalized()
+                )
+            }
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `UNC paths with reserved characters`() {
+        uncPathUrisWithReservedCharacters().forEach { uri ->
+            when {
+                OsFamily.isWindows() -> {
+                    val path = uri.toLocalPathExt().normalized()
+                    assertNull(uri.authority)
+                    assertEquals(
+                        expected = "\\\\WSL$\\Debian\\etc\\passwd",
+                        actual = path.pathString
+                    )
+                    assertNull(path.toFileUri().authority)
+                }
+
+                else -> assertEquals(
+                    expected = "Current OS is not a Windows; unable to construct an absolute Windows path from \"//WSL$/Debian/etc/passwd\"",
+                    actual = assertFailsWith<IllegalArgumentException> {
+                        uri.toLocalPathExt()
+                    }.message,
+                )
+            }
+        }
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `UNC paths`() {
+        uncPathUris().forEach { uri ->
+            when {
+                OsFamily.isWindows() -> {
+                    val path = uri.toLocalPathExt().normalized()
+                    assertEquals("127.0.0.1", uri.authority)
+                    assertEquals(
+                        expected = "\\\\127.0.0.1\\share\\file",
+                        actual = path.pathString
+                    )
+                    assertEquals("127.0.0.1", path.toFileUri().authority)
+                }
+
+                else -> assertEquals(
+                    expected = "Current OS is not a Windows; unable to construct an absolute Windows path from \"//127.0.0.1/share/file\"",
+                    actual = assertFailsWith<IllegalArgumentException> {
+                        uri.toLocalPathExt()
+                    }.message,
+                )
+            }
+        }
+    }
+
+    private companion object {
+        private fun uncPathUrisWithReservedCharacters(): Sequence<Uri> =
+                when {
+                    OsFamily.isWindows() -> sequenceOf(
+                        "\\\\WSL$\\Debian\\etc\\passwd",
+                        "//WSL$/Debian/etc/passwd",
+                    )
+                        .map { it.toPath() }
+                        .map(Path::toFileUri)
+                        .distinctBy(Uri::toString)
+
+                    else -> sequenceOf(Uri("file:////WSL$/Debian/etc/passwd"))
+                }
+
+        private fun uncPathUris(): Sequence<Uri> =
+                when {
+                    OsFamily.isWindows() -> sequenceOf(
+                        "\\\\127.0.0.1\\share\\file",
+                    )
+                        .map { it.toPath() }
+                        .map(Path::toFileUri)
+                        .distinctBy(Uri::toString)
+
+                    else -> sequenceOf(Uri("file:////127.0.0.1/share/file"))
+                }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "1.8.10"
 okio = "3.3.0"
-okio-extras = "1.0"
+okio-extras = "1.1"
 serialization = "1.4.1"
 diktat = "1.2.4.1"
 kotlinx-cli = "0.3.5"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 kotlin = "1.8.10"
 okio = "3.3.0"
+okio-extras = "1.0"
 serialization = "1.4.1"
 diktat = "1.2.4.1"
 kotlinx-cli = "0.3.5"
@@ -28,6 +29,7 @@ kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 okio-fakefilesystem = { module = "com.squareup.okio:okio-fakefilesystem", version.ref = "okio" }
+okio-extras = { module = "com.saveourtool:okio-extras", version.ref = "okio-extras" }
 kotlinx-cli = { module = "org.jetbrains.kotlinx:kotlinx-cli", version.ref = "kotlinx-cli" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
 multiplatform-diff = { module = "io.github.petertrr:kotlin-multiplatform-diff", version.ref = "multiplatform-diff" }


### PR DESCRIPTION
This is intended to eventually address saveourtool/save-cli#489 on Windows and UNIX.

Test cases:

 - an absolute `file://` URI that contains an absolute path: `file:///C:/autoexec.bat`
 - a relative URI (no `file://` scheme) that contains an absolute path with forward slashes: `C:/autoexec.bat`
 - a relative URI (no `file://` scheme) that contains an absolute path with backslashes: `C:\autoexec.bat`
 - an absolute `file://` URI that contains a relative path: `file:autoexec.bat`
 - a relative URI (no `file://` scheme) that contains a relative path: `autoexec.bat`

Support for encoded URIs (e.g.: `file:///C%3A/Program%20Files` &rarr; `file:///C:/Program Files` &rarr; `C:\Program Files`) would require much more effort and is probably out of scope for this issue.
